### PR TITLE
Added a kubectl plugin that works with render

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Just some of the things to `render`:
 - Infrastructure as Code files (e.g. CloudFormation templates)
 - Kubernetes manifests
 
-The renderer extends 
-[go-template](https://golang.org/pkg/text/template/) and [Sprig](http://masterminds.github.io/sprig/) functions. 
+The renderer extends
+[go-template](https://golang.org/pkg/text/template/) and [Sprig](http://masterminds.github.io/sprig/) functions.
 
-If you are interested in one of the use cases, take a look at this [blog post](https://medium.com/virtuslab/helm-alternative-d6568aa9d40b) 
+If you are interested in one of the use cases, take a look at this [blog post](https://medium.com/virtuslab/helm-alternative-d6568aa9d40b)
 about Kubernetes resources rendering. Also see [Helm compatibility](README.md#helm-compatibility).
 
 * [Installation](README.md#installation)
@@ -39,13 +39,17 @@ about Kubernetes resources rendering. Also see [Helm compatibility](README.md#he
 
 For binaries please visit the [Releases Page](https://github.com/VirtusLab/render/releases).
 
-The binaries are statically compiled and does not require any dependencies. 
+The binaries are statically compiled and does not require any dependencies.
 
 #### Via Go
 
 ```console
 $ go get github.com/VirtusLab/render
 ```
+
+#### kubectl command
+
+Place the `kubectl-render_apply` script somewhere in your path and kubectl will automatically find it.
 
 ## Usage
 
@@ -101,6 +105,10 @@ $ ./render --in test.txt.tmpl --out test.txt --config test.config.yaml
 $ cat test.txt
 something new
 ```
+Example usage of `render-apply` with `--in` and `--config`:
+```console
+$ kubectl render-apply --in deployment.yaml.tmpl --config deployment.config.yaml
+```
 
 Also see a [more advanced template](examples/example.yaml.tmpl) example.
 
@@ -149,7 +157,7 @@ All syntax and functions:
 - `toYaml` - provides a configuration data structure fragment as a YAML format
 - `gzip`, `ungzip` - use `gzip` compression and extraction inside the templates, for best results use with `b64enc` and `b64dec`
 
-See also [example](examples/example.yaml.tmpl) template 
+See also [example](examples/example.yaml.tmpl) template
 and a more [detailed documentation](https://godoc.org/github.com/VirtusLab/render/renderer#Renderer.ExtraFunctions).
 
 Cloud KMS (AWS, Amazon, Google) based cryptography functions form [`crypt`](https://github.com/VirtusLab/crypt):
@@ -180,19 +188,19 @@ We provide cross-compiled binaries for most platforms, but is currently used mai
 
 ## Contribution
 
-Feel free to file [issues](https://github.com/VirtusLab/render/issues) 
+Feel free to file [issues](https://github.com/VirtusLab/render/issues)
 or [pull requests](https://github.com/VirtusLab/render/pulls).
 
 ## Development
 
     export GOPATH=$HOME/go
     export PATH=$PATH:$GOPATH/bin
-    
+
     mkdir -p $GOPATH/src/github.com/VirtusLab
     cd $GOPATH/src/github.com/VirtusLab/render
     git clone git@github.com:VirtusLab/render.git
     cd render
-    
+
     go get -u github.com/golang/dep/cmd/dep
     make all
 

--- a/kubectl-render_apply
+++ b/kubectl-render_apply
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+read -d '' usage <<EOF
+NAME:
+   render-apply - Render a template and apply to Kubernetes cluster
+
+USAGE:
+   render-apply [arguments...]
+
+VERSION:
+   v0.1.2-86eb03f
+
+AUTHOR:
+   VirtusLab
+
+COMMANDS:
+
+GLOBAL OPTIONS:
+   --in value                    the input template file, stdin if empty
+   --config value                optional configuration YAML file, can be used multiple times
+   --set value, --var value      additional parameters in key=value format, can be used multiple times
+   --unsafe-ignore-missing-keys  do not fail on missing map key and print '<no value>' ('missingkey=invalid')
+   --help, -h                    show help
+   --version, -v                 print the version
+   --dryrun                      print what arguments will be sent to render, then the formatted file
+EOF
+
+setvalues=""
+
+until [  $# -eq 0 ]; do
+  case $1 in
+  '--in')
+    if [ -z $2 ]; then
+      echo $usage
+      exit
+    elif [ ! -f $2 ]; then
+      echo "file '$2' not found"
+      exit
+    fi
+    in=$2
+    shift 2
+    ;;
+  '--config')
+    if [ -z $2 ]; then
+      echo $usage
+      exit
+    elif [ ! -f $2 ]; then
+      echo "file '$2' not found"
+      exit
+    fi
+    config=$2
+    shift 2
+    ;;
+  '--var') ;&
+  '--set')
+    setvalues="$setvalues $2"
+    shift 2
+    ;;
+  '--unsafe-ignore-missing-keys')
+    unsafe=true
+    shift 1
+    ;;
+  '--dryrun')
+    dryrun=true
+    shift 1
+    ;;
+  '-v') ;&
+  '--version')
+    render --version
+    exit
+    ;;
+  '-h') ;&
+  '--help') ;&
+  *)
+    echo "$usage"
+    exit
+  esac
+done
+
+args=""
+if [ $unsafe ]; then
+  args="$args --unsafe-ignore-missing-keys"
+fi
+
+if [ ! -z $in ]; then
+  if [ ! -f $in ]; then
+    echo "$in is not a file"
+    exit
+  fi
+  args="$args --in $in"
+fi
+
+if [ ! -z $config ]; then
+  if [ ! -f $config ]; then
+    echo "$config is not a file"
+    exit
+  fi
+  args="$args --config $config"
+fi
+
+for var in $setvalues; do
+  args="$args --var $var"
+done
+
+if [ $dryrun ]; then
+  echo "$args"
+  cat <(render $args)
+else
+  kubectl apply -f <(render $args)
+fi


### PR DESCRIPTION
I created a pretty quick kubectl plugin that works for my needs and figured I'd share.
For now it will only handle single files, not directories, but I tried to reuse as much of render's verbs as possible.

My editor also automatically removed some extra whitespace from the `README.md`. I left it in, but I can clean revert that if you want.

Addresses issue #3